### PR TITLE
Ui noninteractive tests - snackbar

### DIFF
--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut-component-example.html
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut-component-example.html
@@ -1,0 +1,6 @@
+<span class="example-ut-snackbar">
+  Snacking from a component!
+</span>
+<br />
+<span>{{ data }}</span>
+<button mat-button color="accent" (click)="snackBarRef.dismiss()">close</button>

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut-component-example.html
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut-component-example.html
@@ -3,4 +3,4 @@
 </span>
 <br />
 <span>{{ data }}</span>
-<button mat-button color="accent" (click)="snackBarRef.dismiss()">close</button>
+<button mat-button color="accent" (click)="snackBarRef.dismiss()">Do the other thing</button>

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
@@ -1,5 +1,6 @@
 <button
   mat-button
+  id='messageButton'
   (click)="openSnackBarMessage()"
   aria-label="Show an example snack-bar"
 >
@@ -8,6 +9,7 @@
 
 <button
   mat-button
+  id='compButton'
   (click)="openSnackBarComponent()"
   aria-label="Show an example snack-bar based on a component"
 >

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
@@ -5,11 +5,3 @@
 >
   SB Message
 </button>
-
-<button
-  mat-button
-  (click)="openSnackBarComponent()"
-  aria-label="Show an example snack-bar with a component"
->
-  SB Component
-</button>

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
@@ -3,5 +3,13 @@
   (click)="openSnackBarMessage()"
   aria-label="Show an example snack-bar"
 >
-  SB Message
+  SB Message 
+</button>
+
+<button
+  mat-button
+  (click)="openSnackBarComponent()"
+  aria-label="Show an example snack-bar based on a component"
+>
+  SB Message from a component
 </button>

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.html
@@ -1,3 +1,15 @@
-<p>
-  snackbar-ut works!
-</p>
+<button
+  mat-button
+  (click)="openSnackBarMessage()"
+  aria-label="Show an example snack-bar"
+>
+  SB Message
+</button>
+
+<button
+  mat-button
+  (click)="openSnackBarComponent()"
+  aria-label="Show an example snack-bar with a component"
+>
+  SB Component
+</button>

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
@@ -1,7 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SnackbarUtComponent } from './snackbar-ut.component';
+import { DebugElement } from '@angular/core';
 
 describe('ui-noninteractive - SnackbarUtComponent', () => {
   let component: SnackbarUtComponent;
@@ -9,10 +10,9 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SnackbarUtComponent ],
-      imports: [ MatSnackBarModule ]
-    })
-    .compileComponents();
+      declarations: [SnackbarUtComponent],
+      imports: [MatSnackBarModule, BrowserAnimationsModule]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
@@ -24,4 +24,61 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // the "should create a snackbar" would be us saying
+  // it should "take action" in a nice real test
+  // like "it should save the order" or "validate the ticket"
+  it('should create a snackbar when the button is clicked', () => {
+    const buttonDe: DebugElement = fixture.debugElement;
+    const buttonEl: HTMLElement = buttonDe.nativeElement;
+
+    // we only have one button on the page, which makes this easy
+    // use the selector that makes sense. You probably want to give that
+    // button an id and class so you can find it more easily on a page with
+    // many elements.
+    const button = buttonEl.querySelector('button');
+
+    // make sure to call detectChanges after initiating some action!
+    // otherwise the fixture won't know it happened.
+    button.click();
+    fixture.detectChanges();
+
+    // our snackbar message lives in
+    // div#cdk-overlay-container -> div#cdk-global-overlay-wrapper -> div#cdk-overlay-0
+    // -> snack-bar-container.mat-snack-bar-container
+    // and in that the message and action are in
+    // -> simple-snack-bar.mat-simple-snackbar (message) -> div.mat-simple-snackbar-action -> button
+
+    const snackingDiv = document.querySelector('snack-bar-container');
+    expect(snackingDiv).toBeTruthy();
+  });
+
+  it('should trigger a snackbar notification when action is taken on the first snackbar', async () => {
+    const buttonDe: DebugElement = fixture.debugElement;
+    const buttonEl: HTMLElement = buttonDe.nativeElement;
+    const button = buttonEl.querySelector('button');
+
+    button.click();
+    fixture.detectChanges();
+
+    spyOn(component, 'openSnackBarComponent');
+
+    const snackingDivButton: HTMLButtonElement = document.querySelector('div.mat-simple-snackbar-action button');
+    snackingDivButton.click();
+
+    console.log(snackingDivButton);
+    fixture.detectChanges();
+
+    expect(component.openSnackBarComponent).toHaveBeenCalled();
+    // expect(snackingDivButton).toBeTruthy();
+  });
+
+  // these are not great tests, we're really testing core functionality and not our
+  // business process.  Now, if the action on our snackbar was to trigger some other
+  // process, test away!
+  it('should do nothing if the first snackbar action is not pressed', () => {});
+
+  it('should dismiss the second snackbar notification when the dismiss button is pressed', () => {});
+
+  it('should dismiss the second snackbar after a 5 second delay', () => {});
 });

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
@@ -3,11 +3,12 @@ import {
   ComponentFixture,
   TestBed
 } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  MatSnackBarModule
+} from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SnackbarUtComponent } from './snackbar-ut.component';
 import { DebugElement } from '@angular/core';
-import { Observable, of } from 'rxjs';
 
 describe('ui-noninteractive - SnackbarUtComponent', () => {
   let component: SnackbarUtComponent;
@@ -34,15 +35,19 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
   // it should "take action" in a nice real test
   // like "it should save the order" or "validate the ticket"
   // the snackbar should be a result of some other thing, not just pressing a button
-  it('should create a snackbar when the button is clicked', () => {
+  it('should create a snackbar from a message when the button is clicked', () => {
     const buttonDe: DebugElement = fixture.debugElement;
     const buttonEl: HTMLElement = buttonDe.nativeElement;
 
-    // we only have one button on the page, which makes this easy
-    // use the selector that makes sense. You probably want to give that
-    // button an id and class so you can find it more easily on a page with
-    // many elements.
-    const button = buttonEl.querySelector('button');
+    // In our case, we have multiple buttons on the page. So it makes sense
+    // to give that button an ID and ref it from there.
+    // we add in the 'as' clause otherwise it's going to return an element, which
+    // won't have the click event.
+    // This isn't all bad, we could always use dispatchEvent, but just as easy
+    // to coerce the button into a type it should be.
+    const button = buttonEl.querySelector(
+      'button#messageButton'
+    ) as HTMLButtonElement;
 
     // make sure to call detectChanges after initiating some action!
     // otherwise the fixture won't know it happened.
@@ -59,19 +64,41 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
     expect(snackingDiv).toBeTruthy();
   });
 
+  // same as above, only using a component for our snackbar
+  it('should create a snackbar using our component when the button is clicked', () => {
+    const buttonDe: DebugElement = fixture.debugElement;
+    const buttonEl: HTMLElement = buttonDe.nativeElement;
+
+    const button = buttonEl.querySelector(
+      'button#compButton'
+    ) as HTMLButtonElement;
+
+    button.click();
+    fixture.detectChanges();
+
+    const snackingDiv = document.querySelector('snack-bar-container');
+    expect(snackingDiv).toBeTruthy();
+  });
+
   // if we were calling out, we might want to mock the service or component
   // and return some value just to be sure the stuff works.
   // We always want to isolate the SUT.
   // In this case we're saying the code that is being called is part of
   // the same component
-  it('should do a thing when action is taken on the first snackbar', async () => {
+  it('should do a thing when action is taken on the first snackbar', () => {
     const buttonDe: DebugElement = fixture.debugElement;
     const buttonEl: HTMLElement = buttonDe.nativeElement;
     const button = buttonEl.querySelector('button');
 
-    // this is a thing that should be done
-    const zeSpy = spyOn(component, 'justWriteAConsoleLog').and.returnValue(
-      of(true)
+    // We're playing here! I'm acting as if the observeSnackBarOnAction method
+    // is calling out maybe to a service, or some other place, and not that
+    // it's calling a method in our own class. Because that's probably what you
+    // would want to do (delegate to some other class for the process behind the
+    // button press)
+    const ourSpy = spyOn(component, 'observeSnackBarOnAction').and.callFake(
+      () => {
+        console.log('We could use a mock or stub here!');
+      }
     );
 
     // click to get our first snackbar
@@ -81,25 +108,24 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
     // find the button on our first snackbar
     const snackingDivButton = document.querySelector(
       'div.mat-simple-snackbar-action button'
-    ) as HTMLButtonElement;
+    );
 
-    // click the button on our first snackbar
-    snackingDivButton.click();
+    // click the button on our first snackbar This will trigger our click event
+    // This time I'll use dispatchEvent, to show how to do this, if we didn't want
+    // to coerce into an HTMLButtonElement
+    const mouseEvent = new MouseEvent('click');
+    snackingDivButton.dispatchEvent(mouseEvent);
+    // still need this!
     fixture.detectChanges();
 
-    fixture.whenStable().then(() => {
-      expect(zeSpy).toHaveBeenCalled();
+    // I'm including our whenRenderingDone call in Jasmine here because we're looking at UI events.
+    // I'm also, below this, using and expect WITHOUT waiting for rendering.
+    // Both will pass.
+    fixture.whenRenderingDone().then(() => {
+      expect(ourSpy).toHaveBeenCalled();
     });
+
+    expect(ourSpy).toHaveBeenCalled();
   });
 
-  it('should call the second snackbar when the first snackbar action is pressed', () => {});
-
-  // these are not great tests, we're really testing core functionality and not our
-  // business process.  Now, if the action on our snackbar was to trigger some other
-  // process, test away!
-  it('should do nothing if the first snackbar action is not pressed', () => {});
-
-  it('should dismiss the second snackbar notification when the dismiss button is pressed', () => {});
-
-  it('should dismiss the second snackbar after a 5 second delay', () => {});
 });

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
@@ -1,6 +1,9 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatSnackBarRef } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SnackbarUtComponent } from './snackbar-ut.component';
 import { DebugElement } from '@angular/core';
@@ -9,17 +12,11 @@ import { Observable, of } from 'rxjs';
 describe('ui-noninteractive - SnackbarUtComponent', () => {
   let component: SnackbarUtComponent;
   let fixture: ComponentFixture<SnackbarUtComponent>;
-  const matSnackSpy = jasmine.createSpyObj('MatSnackBarRef', ['onAction']);
-
-  const onActionMatSnackRefSpy = matSnackSpy.onAction.and.returnValue(
-    of('true')
-  );
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SnackbarUtComponent],
-      imports: [MatSnackBarModule, BrowserAnimationsModule],
-      providers: [{ provide: MatSnackBarRef, useValue: matSnackSpy }]
+      imports: [MatSnackBarModule, BrowserAnimationsModule]
     }).compileComponents();
   }));
 
@@ -36,6 +33,7 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
   // the "should create a snackbar" would be us saying
   // it should "take action" in a nice real test
   // like "it should save the order" or "validate the ticket"
+  // the snackbar should be a result of some other thing, not just pressing a button
   it('should create a snackbar when the button is clicked', () => {
     const buttonDe: DebugElement = fixture.debugElement;
     const buttonEl: HTMLElement = buttonDe.nativeElement;
@@ -61,37 +59,40 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
     expect(snackingDiv).toBeTruthy();
   });
 
-  it('should trigger a snackbar notification when action is taken on the first snackbar', () => {
+  // if we were calling out, we might want to mock the service or component
+  // and return some value just to be sure the stuff works.
+  // We always want to isolate the SUT.
+  // In this case we're saying the code that is being called is part of
+  // the same component
+  it('should do a thing when action is taken on the first snackbar', async () => {
     const buttonDe: DebugElement = fixture.debugElement;
     const buttonEl: HTMLElement = buttonDe.nativeElement;
     const button = buttonEl.querySelector('button');
 
-    spyOn(component, 'openSnackBarMessage').and.callThrough();
-    spyOn(component, 'observeSnackBarOnAction').and.callThrough();
-    spyOn(component, 'openSnackBarComponent').and.callThrough();
+    // this is a thing that should be done
+    const zeSpy = spyOn(component, 'justWriteAConsoleLog').and.returnValue(
+      of(true)
+    );
 
+    // click to get our first snackbar
     button.click();
     fixture.detectChanges();
 
+    // find the button on our first snackbar
     const snackingDivButton = document.querySelector(
       'div.mat-simple-snackbar-action button'
     ) as HTMLButtonElement;
 
+    // click the button on our first snackbar
     snackingDivButton.click();
     fixture.detectChanges();
 
-    expect(component.openSnackBarMessage).toHaveBeenCalled();
-    expect(component.observeSnackBarOnAction).toHaveBeenCalled();
-    expect(component.openSnackBarComponent).toHaveBeenCalled();
+    fixture.whenStable().then(() => {
+      expect(zeSpy).toHaveBeenCalled();
+    });
   });
 
-  it('should call the second snackbar when the first snackbar action is pressed', () => {
-    spyOn(component, 'openSnackBarMessage');
-
-    component.openSnackBarMessage();
-
-    expect(component.openSnackBarMessage).toHaveBeenCalled();
-  });
+  it('should call the second snackbar when the first snackbar action is pressed', () => {});
 
   // these are not great tests, we're really testing core functionality and not our
   // business process.  Now, if the action on our snackbar was to trigger some other

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { SnackbarUtComponent } from './snackbar-ut.component';
 
@@ -8,7 +9,8 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SnackbarUtComponent ]
+      declarations: [ SnackbarUtComponent ],
+      imports: [ MatSnackBarModule ]
     })
     .compileComponents();
   }));

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
@@ -53,24 +53,36 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
     expect(snackingDiv).toBeTruthy();
   });
 
-  it('should trigger a snackbar notification when action is taken on the first snackbar', async () => {
+  it('should trigger a snackbar notification when action is taken on the first snackbar', () => {
     const buttonDe: DebugElement = fixture.debugElement;
     const buttonEl: HTMLElement = buttonDe.nativeElement;
     const button = buttonEl.querySelector('button');
 
+    spyOn(component, 'observeSnackBarOnAction').and.callThrough();
+    spyOn(component, 'openSnackBarMessage').and.callThrough();
+    // spyOn(component, 'openSnackBarComponent').and.callThrough();
+
     button.click();
     fixture.detectChanges();
 
-    spyOn(component, 'openSnackBarComponent');
+    const snackingDivButton = document.querySelector(
+      'div.mat-simple-snackbar-action button'
+    ) as HTMLButtonElement;
 
-    const snackingDivButton: HTMLButtonElement = document.querySelector('div.mat-simple-snackbar-action button');
     snackingDivButton.click();
-
-    console.log(snackingDivButton);
     fixture.detectChanges();
 
-    expect(component.openSnackBarComponent).toHaveBeenCalled();
-    // expect(snackingDivButton).toBeTruthy();
+    expect(component.observeSnackBarOnAction).toHaveBeenCalled();
+    // expect(component.openSnackBarComponent).toHaveBeenCalled();
+    expect(component.openSnackBarMessage).toHaveBeenCalled();
+  });
+
+  it('should call the second snackbar when the first snackbar action is pressed', () => {
+    spyOn(component, 'openSnackBarMessage');
+
+    component.openSnackBarMessage();
+
+    expect(component.openSnackBarMessage).toHaveBeenCalled();
   });
 
   // these are not great tests, we're really testing core functionality and not our

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.spec.ts
@@ -1,17 +1,25 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSnackBarRef } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SnackbarUtComponent } from './snackbar-ut.component';
 import { DebugElement } from '@angular/core';
+import { Observable, of } from 'rxjs';
 
 describe('ui-noninteractive - SnackbarUtComponent', () => {
   let component: SnackbarUtComponent;
   let fixture: ComponentFixture<SnackbarUtComponent>;
+  const matSnackSpy = jasmine.createSpyObj('MatSnackBarRef', ['onAction']);
+
+  const onActionMatSnackRefSpy = matSnackSpy.onAction.and.returnValue(
+    of('true')
+  );
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SnackbarUtComponent],
-      imports: [MatSnackBarModule, BrowserAnimationsModule]
+      imports: [MatSnackBarModule, BrowserAnimationsModule],
+      providers: [{ provide: MatSnackBarRef, useValue: matSnackSpy }]
     }).compileComponents();
   }));
 
@@ -58,9 +66,9 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
     const buttonEl: HTMLElement = buttonDe.nativeElement;
     const button = buttonEl.querySelector('button');
 
-    spyOn(component, 'observeSnackBarOnAction').and.callThrough();
     spyOn(component, 'openSnackBarMessage').and.callThrough();
-    // spyOn(component, 'openSnackBarComponent').and.callThrough();
+    spyOn(component, 'observeSnackBarOnAction').and.callThrough();
+    spyOn(component, 'openSnackBarComponent').and.callThrough();
 
     button.click();
     fixture.detectChanges();
@@ -72,9 +80,9 @@ describe('ui-noninteractive - SnackbarUtComponent', () => {
     snackingDivButton.click();
     fixture.detectChanges();
 
-    expect(component.observeSnackBarOnAction).toHaveBeenCalled();
-    // expect(component.openSnackBarComponent).toHaveBeenCalled();
     expect(component.openSnackBarMessage).toHaveBeenCalled();
+    expect(component.observeSnackBarOnAction).toHaveBeenCalled();
+    expect(component.openSnackBarComponent).toHaveBeenCalled();
   });
 
   it('should call the second snackbar when the first snackbar action is pressed', () => {

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
@@ -22,6 +22,7 @@ export class SnackbarUTExampleComponent {
   styleUrls: ['./snackbar-ut.component.css']
 })
 export class SnackbarUtComponent {
+
   constructor(private _snackBar: MatSnackBar) {}
 
   // We're simulating a button click doing some thing, and that thing

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
@@ -21,13 +21,30 @@ export class SnackbarUTExampleComponent {
   templateUrl: './snackbar-ut.component.html',
   styleUrls: ['./snackbar-ut.component.css']
 })
-export class SnackbarUtComponent implements OnInit {
+export class SnackbarUtComponent {
   constructor(private _snackBar: MatSnackBar) {}
 
-  ngOnInit() {}
-
+  // We're simulating a button click doing some thing, and that thing
+  // triggering a snackbar notification.
+  // In this case the thing is dismissing the first snackbar!
+  // Of course, the snackbar principals exist
+  // They should provide information
+  // they should be temporary (disappear without action in a short time)
+  // placed in the UI in a good place
+  // so we're going to not do the action if the action isn't pressed!
   openSnackBarMessage() {
-    this._snackBar.open('Snacking message', 'dismiss');
+    // snackbar principals -
+    // They should provide information
+    // they should be temporary (disappear without action in a short time)
+    // placed in the UI in a good place
+    const firstSnackBarRef = this._snackBar.open(
+      'Snacking message',
+      'do the thing',
+      { duration: 5000 }
+    );
+    firstSnackBarRef.onAction().subscribe(() => {
+      this.openSnackBarComponent();
+    });
   }
 
   // We wanted a little pause here. Why? Because a nice use
@@ -38,13 +55,10 @@ export class SnackbarUtComponent implements OnInit {
   // data in a document.
   openSnackBarComponent() {
     setTimeout(() => {
-      let snackbarRef = this._snackBar.openFromComponent(
-        SnackbarUTExampleComponent,
-        {
-          duration: 5000,
-          data: 'Hey! This took an extra second to show!'
-        }
-      );
+      this._snackBar.openFromComponent(SnackbarUTExampleComponent, {
+        duration: 5000,
+        data: 'Hey! This took an extra second to show!'
+      });
     }, 1000);
   }
 }

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
@@ -42,6 +42,10 @@ export class SnackbarUtComponent {
       'do the thing',
       { duration: 5000 }
     );
+
+    this.observeSnackBarOnAction(firstSnackBarRef);
+  }
+  observeSnackBarOnAction(firstSnackBarRef) {
     firstSnackBarRef.onAction().subscribe(() => {
       this.openSnackBarComponent();
     });

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
@@ -46,9 +46,16 @@ export class SnackbarUtComponent {
     this.observeSnackBarOnAction(firstSnackBarRef);
   }
   observeSnackBarOnAction(firstSnackBarRef) {
-    return firstSnackBarRef.onAction().subscribe(() => {
-      this.openSnackBarComponent();
+    firstSnackBarRef.onAction().subscribe(() => {
+      // really this would be, hey do some business logic
+      // based on the button in the first snack bar being pressed
+      // We're just showing how you can open a snackbar component though
+      this.justWriteAConsoleLog();
     });
+  }
+
+  justWriteAConsoleLog() {
+    console.log('Doing a thing based on the second button press');
   }
 
   // We wanted a little pause here. Why? Because a nice use
@@ -58,7 +65,6 @@ export class SnackbarUtComponent {
   // the user Hey! You just got a message!  While they're typing
   // data in a document.
   openSnackBarComponent() {
-    console.log('it\'s been called');
     setTimeout(() => {
       this._snackBar.openFromComponent(SnackbarUTExampleComponent, {
         duration: 5000,

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
@@ -46,7 +46,7 @@ export class SnackbarUtComponent {
     this.observeSnackBarOnAction(firstSnackBarRef);
   }
   observeSnackBarOnAction(firstSnackBarRef) {
-    firstSnackBarRef.onAction().subscribe(() => {
+    return firstSnackBarRef.onAction().subscribe(() => {
       this.openSnackBarComponent();
     });
   }
@@ -58,6 +58,7 @@ export class SnackbarUtComponent {
   // the user Hey! You just got a message!  While they're typing
   // data in a document.
   openSnackBarComponent() {
+    console.log('it\'s been called');
     setTimeout(() => {
       this._snackBar.openFromComponent(SnackbarUTExampleComponent, {
         duration: 5000,

--- a/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
+++ b/src/app/ui-noninteractive-tests/snackbar-ut/snackbar-ut.component.ts
@@ -1,4 +1,20 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
+import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
+import { MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+
+// This component is dynamically loaded, so make sure you add it into the
+// module's entry components so you can get your ComponentFactory compiled in
+@Component({
+  selector: 'app-snackbar-ut-example',
+  templateUrl: 'snackbar-ut-component-example.html',
+  styleUrls: ['./snackbar-ut.component.css']
+})
+export class SnackbarUTExampleComponent {
+  constructor(
+    public snackBarRef: MatSnackBarRef<SnackbarUTExampleComponent>,
+    @Inject(MAT_SNACK_BAR_DATA) public data: any
+  ) {}
+}
 
 @Component({
   selector: 'app-snackbar-ut',
@@ -6,10 +22,29 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./snackbar-ut.component.css']
 })
 export class SnackbarUtComponent implements OnInit {
+  constructor(private _snackBar: MatSnackBar) {}
 
-  constructor() { }
+  ngOnInit() {}
 
-  ngOnInit() {
+  openSnackBarMessage() {
+    this._snackBar.open('Snacking message', 'dismiss');
   }
 
+  // We wanted a little pause here. Why? Because a nice use
+  // of snackbar is for notifications that pop up in a browser
+  // when some other process needs to notify the user!
+  // Think of a private message type function that wants to tell
+  // the user Hey! You just got a message!  While they're typing
+  // data in a document.
+  openSnackBarComponent() {
+    setTimeout(() => {
+      let snackbarRef = this._snackBar.openFromComponent(
+        SnackbarUTExampleComponent,
+        {
+          duration: 5000,
+          data: 'Hey! This took an extra second to show!'
+        }
+      );
+    }, 1000);
+  }
 }

--- a/src/app/ui-noninteractive-tests/tooltip-ut/tooltip-ut.component.spec.ts
+++ b/src/app/ui-noninteractive-tests/tooltip-ut/tooltip-ut.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTooltipModule } from '@angular/material/tooltip';
 // we'll use this in case we're testing on a non-html platform
 import { DebugElement } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { TooltipUtComponent } from './tooltip-ut.component';
 import { By } from '@angular/platform-browser';
@@ -15,7 +16,7 @@ describe('ui-noninteractive - TooltipUtComponent', () => {
       declarations: [TooltipUtComponent],
       // We need to import the tooltip module, or we'll get errors that
       // the material module we're testing isn't a known property
-      imports: [MatTooltipModule]
+      imports: [MatTooltipModule, NoopAnimationsModule]
     }).compileComponents();
   }));
 

--- a/src/app/ui-noninteractive-tests/ui-noninteractive-tests.module.ts
+++ b/src/app/ui-noninteractive-tests/ui-noninteractive-tests.module.ts
@@ -2,12 +2,13 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { CardUtComponent } from './card-ut/card-ut.component';
 import { ListUtComponent } from './list-ut/list-ut.component';
 import { BottomsheetUtComponent } from './bottomsheet-ut/bottomsheet-ut.component';
 import { DialogUtComponent } from './dialog-ut/dialog-ut.component';
-import { SnackbarUtComponent } from './snackbar-ut/snackbar-ut.component';
+import { SnackbarUtComponent, SnackbarUTExampleComponent } from './snackbar-ut/snackbar-ut.component';
 import { TooltipUtComponent } from './tooltip-ut/tooltip-ut.component';
 import { DatatableUtComponent } from './datatable-ut/datatable-ut.component';
 import { GeneralLayoutComponent } from './general-layout/general-layout.component';
@@ -20,10 +21,18 @@ import { UINoninteractiveTestsRoutingModule } from './ui-noninteractive-test-rou
     BottomsheetUtComponent,
     DialogUtComponent,
     SnackbarUtComponent,
+    SnackbarUTExampleComponent,
     TooltipUtComponent,
     DatatableUtComponent,
     GeneralLayoutComponent
   ],
-  imports: [CommonModule, UINoninteractiveTestsRoutingModule, MatButtonModule, MatTooltipModule]
+  imports: [
+    CommonModule,
+    UINoninteractiveTestsRoutingModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatSnackBarModule
+  ],
+  entryComponents: [ SnackbarUTExampleComponent ]
 })
 export class UiNoninteractiveTestsModule {}


### PR DESCRIPTION
Added in simple snackbar tests, so we can see how to ref a snackbar when it's called. These tests also show how to spy on a call from within a snackbar press.